### PR TITLE
Update phpseclib version

### DIFF
--- a/src/Magento/Deployer/Model/PrepareStrategy/VcsStrategy.php
+++ b/src/Magento/Deployer/Model/PrepareStrategy/VcsStrategy.php
@@ -121,7 +121,7 @@ class VcsStrategy {
             $composer->addRequire('endroid/qr-code', '^3.7');
             $composer->addRequire('donatj/phpuseragentparser', '~0.7');
             $composer->addRequire('2tvenom/cborencode', '^1.0');
-            $composer->addRequire('phpseclib/phpseclib', '2.0.*');
+            $composer->addRequire('phpseclib/phpseclib', '^3.0');
         }
 
         $repos = [];


### PR DESCRIPTION
Hi @nathanjosiah ,

This PR solves an issue with outdated `phpseclib` package version, which causes conflicts during cloud installation:

```
Executing build hook...
    (...)
    W: - Required package "phpseclib/phpseclib" is in the lock file as "3.0.18" but that does not satisfy your constraint "2.0.*".
    W: This usually happens when composer files are incorrectly merged or the composer.json file is manually edited.
    (...)

  E: Error building project: Step failed with status code 4.

E: Error: Unable to build application, aborting.
```

We have confirmed that changing `phpseclib` version in generated `composer.json` to `^3.0` resolves the issue.

Let me know if you need any additional information on this PR.

Cheers,
Rafal
