### PR TITLE
Bump endroid/qr-code to fix QR code generation for 2FA setup

### DIFF
--- a/src/Magento/Deployer/Model/PrepareStrategy/VcsStrategy.php
+++ b/src/Magento/Deployer/Model/PrepareStrategy/VcsStrategy.php
@@ -118,7 +118,7 @@ class VcsStrategy {
             $composer->addRequire('google/recaptcha', '^1.2');
             $composer->addRequire('christian-riesen/base32', '^1.3');
             $composer->addRequire('spomky-labs/otphp', '^10.0');
-            $composer->addRequire('endroid/qr-code', '^3.7');
+            $composer->addRequire('endroid/qr-code', '^4.0');
             $composer->addRequire('donatj/phpuseragentparser', '~0.7');
             $composer->addRequire('2tvenom/cborencode', '^1.0');
             $composer->addRequire('phpseclib/phpseclib', '^3.0');


### PR DESCRIPTION
Hi @nathanjosiah,

This PR bumps version of `endroid/qr-code` to fix an issue which causes critical exception being thrown during 2FA setup (QR code was not generated due to reference of missing class added in version 4 of `qr-code` package)

I have confirmed new version works fine and cloud instance works correctly, eg. QR code is generated withou an issue and 2FA setup process works.

Let me know if you have any questions regarding this PR.

Cheers,
Rafal